### PR TITLE
Update docfx to version 2.56.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,24 @@ FROM mono:latest
 LABEL maintainer="tsgkadot<tsgkadot@gmail.com>" \
       description="For DocFX building(with mono.)"
 
-ENV DOCFX_VER 2.36
+ENV DOCFX_VER 2.56.7
 
-RUN apt-get update && apt-get install unzip wget git -y && \
-    wget -q -P /tmp https://github.com/dotnet/docfx/releases/download/v${DOCFX_VER}/docfx.zip && \
-    mkdir -p /opt/docfx && \
-    unzip /tmp/docfx.zip -d /opt/docfx && \
-    echo '#!/bin/bash\nmono /opt/docfx/docfx.exe $@' > /usr/bin/docfx && \
-    chmod +x /usr/bin/docfx && \
-    rm -f /tmp/*
+RUN apt-get update \
+ && apt-get install unzip wget git -y \
+ && rm -rf /var/lib/apt/lists/* \
+ && wget -q -P /tmp https://github.com/dotnet/docfx/releases/download/v${DOCFX_VER}/docfx.zip \
+ && mkdir -p /opt/docfx \
+ && unzip /tmp/docfx.zip -d /opt/docfx \
+ && echo '#!/bin/bash\nmono /opt/docfx/docfx.exe $@' > /usr/bin/docfx \
+ && chmod +x /usr/bin/docfx \
+ && rm -f /tmp/*
+
+# Configure the tools
+RUN mkdir -p /source
+
+WORKDIR /source
+
+ENTRYPOINT ["docfx"]
 
 CMD ["docfx", "-h"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM mono:latest
+FROM brebete/dotnet-mono:latest
 
 LABEL maintainer="tsgkadot<tsgkadot@gmail.com>" \
+      updater="Heberte F Moraes<brebete@gmail.com>" \
       description="For DocFX building(with mono.)"
 
 ENV DOCFX_VER 2.56.7

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 tsgkdt
+Copyright (c) 2021 tsgkdt
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Docker image for [DocFX](http://dotnet.github.io/docfx/).
 # Spec
 
 | Product | Version |
-|--------|---------|
-| DocFX  | 2.36    |
+|---------|---------|
+| DocFX   | 2.56.7  |
 
 # How to use
 
@@ -31,8 +31,8 @@ $ docker run --rm -it tsgkadot/docker-docfx:latest docfx help
 ```
 
 ```
-docfx 2.36.0.0
-Copyright (C) 2018 © Microsoft Corporation. All rights reserved.
+docfx 2.56.7.0
+Copyright (C) 2021 ? Microsoft Corporation. All rights reserved.
 This is open-source software under MIT License.
    Usage1: docfx <docfx.json file path> [-o <output folder path>]
    Usage2: docfx <subcommand> [<args>]


### PR DESCRIPTION
- Set WORKDIR to /source (allow mount project volume in /source)
- Set ENTRYPOINT the tool docfx as default

I will try create a image with this tool and dotnet tool together, allowing to automate doc build